### PR TITLE
fix(runner): stream text from two-phase agy step writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Install with pi's package manager:
 pi install npm:@estebanforge/pi-antigravity-bridge
 ```
 
-Requires the **`agy` CLI** installed and authenticated. If you don't have it, follow Google's [official install guide](https://antigravity.google/docs/cli/install) for your platform, then run `agy` once to complete Google OAuth. The extension resolves `agy` on `$PATH`, or via the `AGY_BIN` environment variable.
+Requires the **`agy` CLI** installed and authenticated. Tested against agy 1.1.7 and 1.1.18; other versions are untested, but decoding is version-agnostic — unknown payloads fail soft, with a visible warning when a turn's text could not be decoded (see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)). If you don't have it, follow Google's [official install guide](https://antigravity.google/docs/cli/install) for your platform, then run `agy` once to complete Google OAuth. The extension resolves `agy` on `$PATH`, or via the `AGY_BIN` environment variable.
 
 Also requires Node 22.5 or newer (uses the built-in `node:sqlite`).
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -24,22 +24,30 @@ No generated protobuf code, no native SQLite dependency.
 
 ## The decode pipeline
 
-agy writes each step to a SQLite row with a protobuf blob in `step_payload`. The text we want lives at field 20, submessage field 1. Tool calls live at field 5, submessage field 4, with the name at field 2 or 9 and the raw input JSON at field 3. These field numbers are reverse-engineered facts (cross-checked against the shindgew/agy-acp and shubzkothekar/antigravity-acp decoders, then verified against real databases on agy 1.1.7). They are load-bearing. Unknown fields are skipped per protobuf wire rules, so a future agy that adds fields will not break decoding.
+agy writes each step to a SQLite row with a protobuf blob in `step_payload`. The text we want lives at field 20, submessage field 1. Tool calls live at field 5, submessage field 4, with the name at field 2 or 9 and the raw input JSON at field 3. These field numbers are reverse-engineered facts (cross-checked against the shindgew/agy-acp and shubzkothekar/antigravity-acp decoders, verified against real databases on agy 1.1.7, and re-verified on agy 1.1.18 for agent text and title). They are load-bearing. Unknown fields are skipped per protobuf wire rules, so a future agy that adds fields will not break decoding.
 
 ### Step types
 
 | step_type | meaning |
 | --- | --- |
 | 15 | agent text (payload field 20 -> field 1) |
-| 14 | thinking |
+| 14 | thinking (same payload path on 1.1.7-era DBs) |
 | 23 | title update (payload field 30 -> field 4) |
 | 5, 7, 8, 9, 17, 21, 33, 101, 132, 138 | tool run (payload field 5 -> field 4 -> name@2/9, input@3) |
 
 Status 3 = complete; anything else = in-flight.
 
+On agy 1.1.18, type-14 (thinking) payloads no longer carry text at field 20.1 (observed instead: field 5 = metadata submessage, field 19 = turn context; the introducing version is unknown). Thinking steps from that generation decode to null and are dropped — a known limitation left to a follow-up change.
+
+### Two-phase writes (observed on agy >= 1.1.18)
+
+Some agy versions commit an agent-text row in TWO phases — observed on 1.1.18, absent in 1.1.7-era behavior, exact introducing version unknown (the public changelog does not document storage details): first a metadata-only placeholder frame (status != 3, field 20 present but empty), then the same row grows IN PLACE until its final content lands under field 20.1 and status flips to complete. The first observation of such a row therefore decodes to null by design.
+
+To tolerate this without any version detection, the runner arms a pending entry for EVERY text-like row on first sight — regardless of decode outcome — and re-reads each entry whenever a commit lands, emitting grown suffixes as deltas. An entry settles once its row is complete and its decoded length stopped growing across consecutive reads. Legacy agy (single-phase, pre-filled rows) streams exactly as before; entries just settle after their second confirming read. If a turn ends with completed agent-text rows but zero decoded characters, the runner emits a single `warning` event, so a future layout shift surfaces as a visible hint instead of a silent empty response.
+
 ## Polling
 
-The runner spawns `agy -p`, then polls its conversation DB on a 250ms interval concurrent with the running process (this is what makes the provider actually stream, not replay at exit). Each tick issues a single `PRAGMA data_version` check; while agy is thinking and has not committed, that check is false and no row SELECT runs at all (neither the new-row read nor the in-place re-read of the step agy is currently extending). Only when a commit lands do both reads fire in one pass. Three trailing polls at 100ms after agy exits catch the last flush; on abort these are skipped so cancellation is prompt.
+The runner spawns `agy -p`, then polls its conversation DB on a 250ms interval concurrent with the running process (this is what makes the provider actually stream, not replay at exit). Each tick issues a single `PRAGMA data_version` check; while agy is thinking and has not committed, that check is false and nothing is read at all. When a commit lands, the tick re-reads every pending text-like row (see two-phase writes above) and fetches newly appended rows in one pass. Three trailing polls at 100ms after agy exits catch the last flush; on abort these are skipped so cancellation is prompt.
 
 ## Conversation id discovery
 

--- a/scripts/run-agy.ts
+++ b/scripts/run-agy.ts
@@ -107,6 +107,9 @@ const onEvent = (event: AgyEvent) => {
 		case "title":
 			// Title updates are metadata; note but don't clutter the stream.
 			break;
+		case "warning":
+			process.stdout.write(`\n${stamp()} [agy warning] ${event.text}\n`);
+			break;
 	}
 };
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -410,6 +410,10 @@ async function runTurn(
 			case "title":
 				// Conversation title metadata  -  not streamed to the user.
 				break;
+			case "warning":
+				// Turn-end decoder diagnostics: visible hint, not response content.
+				appendThinking(`${event.text}\n`);
+				break;
 		}
 	};
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -49,7 +49,8 @@ export type AgyEvent =
 	| { kind: "text"; text: string }
 	| { kind: "thinking"; text: string }
 	| { kind: "tool"; name: string; inputJson: string }
-	| { kind: "title"; title: string };
+	| { kind: "title"; title: string }
+	| { kind: "warning"; text: string };
 
 // step_type values observed in real DBs. Tool steps share the same payload
 // layout (field 5 -> toolCall), so we decode them uniformly. Unknown types
@@ -189,27 +190,55 @@ export async function runAgyTurn(
 
 	// One poller per turn, lazily opened once we know the conversation id.
 	let poller: ConversationPoller | null = null;
-	// agy extends the step it is currently writing in place (same idx, growing
-	// text). poll() returns only idx > lastIdx, so we re-read the last
-	// text/thinking step each tick and emit the grown suffix as a delta.
-	// flushStreamStep also runs BEFORE the loop so a step boundary landing
-	// inside this tick doesn't drop the outgoing step's final in-place tail
-	// (the loop may switch streamIdx to a new idx before we'd re-read).
-	let streamIdx = -1;
-	let streamKind: "text" | "thinking" | null = null;
-	let streamEmitted = 0;
-	const flushStreamStep = (): void => {
-		if (streamIdx < 0 || !poller || !streamKind) return;
-		const s = poller.readStepAt(streamIdx);
-		if (!s) return;
-		try {
-			const t = extractAgentText(s.payload);
-			if (t && t.text.length > streamEmitted) {
-				onEvent({ kind: streamKind, text: t.text.slice(streamEmitted) });
-				streamEmitted = t.text.length;
+
+	// agy commits agent-text/thinking rows in TWO phases (observed on agy
+	// 1.1.18; absent in 1.1.7-era behavior; exact introducing version unknown):
+	// first a metadata-only placeholder frame (status != 3, protobuf
+	// field 20 present but empty), then the same row grows IN PLACE until its
+	// final content lands under field 20.1 with status flipped to complete.
+	// extractAgentText therefore returns null on FIRST sight of such a row, so
+	// we arm a pending entry for EVERY text-like row on first sight - regardless
+	// of decode outcome - and re-read each entry on every tick where a commit
+	// landed, emitting grown suffixes as deltas. An entry settles once its row
+	// is complete AND its decoded length stopped growing across consecutive
+	// reads. See docs/ARCHITECTURE.md ("Two-phase writes").
+	interface PendingStream {
+		kind: "text" | "thinking";
+		emitted: number;
+		lastLen: number;
+	}
+	const pendingStreams = new Map<number, PendingStream>();
+	// Diagnostics for the turn-end zero-decode warning: did agy complete at
+	// least one agent-text row, and did any text actually reach the caller?
+	let sawCompletedTextRow = false;
+	let emittedTextChars = 0;
+	const emit = (event: AgyEvent): void => {
+		if (event.kind === "text") emittedTextChars += event.text.length;
+		onEvent(event);
+	};
+	const flushPendingStreams = (): void => {
+		if (!poller) return;
+		for (const [idx, p] of pendingStreams) {
+			const s = poller.readStepAt(idx);
+			if (!s) continue;
+			if (s.stepType === 15 && s.status === 3) sawCompletedTextRow = true;
+			try {
+				const t = extractAgentText(s.payload);
+				const len = t ? t.text.length : 0;
+				if (t && len > p.emitted) {
+					emit({ kind: p.kind, text: t.text.slice(p.emitted) });
+					p.emitted = len;
+				}
+				// Settled: complete and stable across consecutive reads. The -1
+				// sentinel guarantees at least one confirming read per entry.
+				if (s.status === 3 && len === p.lastLen && p.lastLen !== -1) {
+					pendingStreams.delete(idx);
+				} else {
+					p.lastLen = len;
+				}
+			} catch {
+				/* torn re-read; next poll retries */
 			}
-		} catch {
-			/* torn re-read; next poll retries */
 		}
 	};
 	const pollOnce = (): boolean => {
@@ -234,14 +263,15 @@ export async function runAgyTurn(
 		if (!poller.isOpen && !poller.tryOpen()) return false;
 
 		// Coalesce: one data_version check per tick gates BOTH the in-place
-		// re-read (flushStreamStep -> readStepAt) and the new-row read. While
+		// re-read (flushPendingStreams -> readStepAt) and the new-row read. While
 		// agy is thinking and hasn't committed, hasChanged() is false and we
 		// skip both SELECTs, so no row read fires on an idle tick.
 		if (!poller.hasChanged()) return false;
 
-		// Catch the currently-tracked step's final in-place growth BEFORE the
-		// loop may switch tracking to a new step.
-		flushStreamStep();
+		// Catch every tracked step's final in-place growth BEFORE processing
+		// new rows, so an outgoing step's tail isn't dropped if this tick arms
+		// newer rows.
+		flushPendingStreams();
 		const steps = poller.readNewSteps();
 		for (const step of steps) {
 			// A torn read (agy mid-write) can throw RangeError out of the protobuf
@@ -250,19 +280,30 @@ export async function runAgyTurn(
 			// to the decode layer where the throw actually originates.)
 			try {
 				const event = decodeStep(step);
-				if (event) {
-					onEvent(event);
-					if (event.kind === "text" || event.kind === "thinking") {
-						streamIdx = step.idx;
-						streamKind = event.kind;
-						streamEmitted = event.text.length;
-					}
+				if (event) emit(event);
+				// Arm tracking on FIRST sight of every text-like row, decoded or
+				// not: placeholder frames decode to null today but carry their
+				// content later via in-place growth (two-phase writes).
+				if (
+					(step.stepType === 15 || step.stepType === 14) &&
+					!pendingStreams.has(step.idx)
+				) {
+					const decodedLen =
+						event && (event.kind === "text" || event.kind === "thinking")
+							? event.text.length
+							: 0;
+					pendingStreams.set(step.idx, {
+						kind: step.stepType === 15 ? "text" : "thinking",
+						emitted: decodedLen,
+						lastLen: -1,
+					});
 				}
+				if (step.stepType === 15 && step.status === 3) sawCompletedTextRow = true;
 			} catch {
 				/* drop undecodable step; lastIdx still advances past it */
 			}
 		}
-		flushStreamStep();
+		flushPendingStreams();
 		lastIdx = poller.lastIdx;
 		return steps.length > 0;
 	};
@@ -371,7 +412,20 @@ export async function runAgyTurn(
 		for (let i = 0; i < TRAILING_POLLS; i++) {
 			pollOnce();
 			await sleep(TRAILING_POLL_MS);
+			flushPendingStreams();
 		}
+	}
+
+	// Turn-end diagnostics: agy completed agent-text
+	// rows while nothing reached the caller means its DB layout drifted beyond
+	// this bridge's decoder. Surface it once instead of failing silently empty.
+	if (sawCompletedTextRow && emittedTextChars === 0) {
+		onEvent({
+			kind: "warning",
+			text:
+				"[agy] agent-text step(s) were written but none could be decoded; " +
+				"agy's conversation DB format may have changed beyond what this bridge supports.",
+		});
 	}
 
 	// CFA note: poller/proc are assigned inside closures that TS can't track

--- a/tests/runner-streaming.test.ts
+++ b/tests/runner-streaming.test.ts
@@ -160,3 +160,146 @@ test("runAgyTurn aborts promptly and skips trailing polls", async () => {
 
 	fs.rmSync(tmp, { recursive: true, force: true });
 });
+
+// Regression guard for agy "two-phase writes" (observed on 1.1.18; the
+// introducing version is unknown - not present in 1.1.7-era behavior):
+// the agent-text row is FIRST committed as a metadata-only placeholder frame
+// (status != 3, protobuf field 20 present but empty) and only later grows,
+// in place, into its final content under the SAME idx. The old single-shot
+// tracking armed only after a successful decode, so a null decode on first
+// sight meant the row was skipped forever - pi showed an empty response even
+// though the settled DB held perfect text (decode-db proved it).
+test("runAgyTurn streams text from a two-phase placeholder -> filled row", async () => {
+	const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "agy-two-phase-"));
+	const convDir = path.join(tmp, "conversations");
+	fs.mkdirSync(convDir, { recursive: true });
+	const fakeBin = path.join(tmp, "fake-agy-two-phase.mjs");
+	const script = `#!/usr/bin/env node
+import { DatabaseSync } from "node:sqlite";
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+
+const dir = process.env.AGY_FAKE_CONV_DIR;
+if (!dir) { console.error("AGY_FAKE_CONV_DIR unset"); process.exit(2); }
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function agentText(text) {
+  const textBytes = Buffer.from(text, "utf8");
+  const inner = Buffer.concat([Buffer.from([0x0a, textBytes.length]), textBytes]);
+  return Buffer.concat([Buffer.from([0xa2, 0x01, inner.length]), inner]);
+}
+
+// Placeholder frame captured live from agy 1.1.18: step_type=15 (field 1),
+// status=8/in-flight (field 4), field 20 present but EMPTY.
+function placeholderFrame() {
+  return Buffer.from([0x08, 0x0f, 0x20, 0x08, 0xa2, 0x01, 0x00]);
+}
+
+await sleep(150);
+const dbPath = path.join(dir, randomUUID() + ".db");
+const db = new DatabaseSync(dbPath);
+db.exec("CREATE TABLE steps (idx integer, step_type integer NOT NULL DEFAULT 0, status integer NOT NULL DEFAULT 0, step_payload blob, PRIMARY KEY (idx))");
+const ins = db.prepare("INSERT INTO steps (idx, step_type, status, step_payload) VALUES (?,?,?,?)");
+
+await sleep(300);
+ins.run(0, 15, 8, placeholderFrame()); // phase 1: decodes to null
+await sleep(400);
+db.prepare("UPDATE steps SET status = ?, step_payload = ? WHERE idx = 0")
+  .run(3, agentText("recovered tail")); // phase 2: same row grows in place
+db.close();
+process.exit(0);
+`;
+	fs.writeFileSync(fakeBin, script, { mode: 0o755 });
+
+	process.env.AGY_FAKE_CONV_DIR = convDir;
+	const events: AgyEvent[] = [];
+	const result = await runAgyTurn(
+		{
+			cwd: tmp,
+			prompt: "ignored by fake",
+			conversationsDir: convDir,
+			binary: fakeBin,
+			timeoutMin: 1,
+		},
+		(event) => events.push(event),
+	);
+	delete process.env.AGY_FAKE_CONV_DIR;
+
+	const texts = events
+		.filter((e): e is Extract<AgyEvent, { kind: "text" }> => e.kind === "text")
+		.map((e) => e.text)
+		.join("");
+
+	assert.equal(result.exitCode, 0, "fake agy should exit 0");
+	assert.equal(result.lastIdx, 0, "should have seen the placeholder row");
+	assert.equal(
+		texts,
+		"recovered tail",
+		`placeholder frame's eventual content must be streamed, got ${JSON.stringify(texts)}`,
+	);
+	assert.equal(
+		events.filter((e) => e.kind === "warning").length,
+		0,
+		"no warning when text was successfully decoded",
+	);
+
+	fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+// Turn-end diagnostics: if agy completes agent-text
+// rows but NONE of them decode (a future layout shift), the caller gets one
+// visible warning instead of a silently empty response.
+test("runAgyTurn warns once when completed text rows never decode", async () => {
+	const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "agy-undecodable-"));
+	const convDir = path.join(tmp, "conversations");
+	fs.mkdirSync(convDir, { recursive: true });
+	const fakeBin = path.join(tmp, "fake-agy-undecodable.mjs");
+	const script = `#!/usr/bin/env node
+import { DatabaseSync } from "node:sqlite";
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+
+const dir = process.env.AGY_FAKE_CONV_DIR;
+if (!dir) { console.error("AGY_FAKE_CONV_DIR unset"); process.exit(2); }
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+await sleep(150);
+const dbPath = path.join(dir, randomUUID() + ".db");
+const db = new DatabaseSync(dbPath);
+db.exec("CREATE TABLE steps (idx integer, step_type integer NOT NULL DEFAULT 0, status integer NOT NULL DEFAULT 0, step_payload blob, PRIMARY KEY (idx))");
+const ins = db.prepare("INSERT INTO steps (idx, step_type, status, step_payload) VALUES (?,?,?,?)");
+
+await sleep(300);
+// Complete agent-text row (status=3) whose payload has NO field 20 - i.e. a
+// layout this bridge's extractor cannot navigate.
+ins.run(0, 15, 3, Buffer.from([0x08, 0x0f, 0x20, 0x03, 0x2a, 0x05, 0x01, 0x02, 0x03, 0x04, 0x05]));
+db.close();
+process.exit(0);
+`;
+	fs.writeFileSync(fakeBin, script, { mode: 0o755 });
+
+	process.env.AGY_FAKE_CONV_DIR = convDir;
+	const events: AgyEvent[] = [];
+	const result = await runAgyTurn(
+		{
+			cwd: tmp,
+			prompt: "ignored by fake",
+			conversationsDir: convDir,
+			binary: fakeBin,
+			timeoutMin: 1,
+		},
+		(event) => events.push(event),
+	);
+	delete process.env.AGY_FAKE_CONV_DIR;
+
+	const warnings = events.filter((e) => e.kind === "warning");
+	assert.equal(result.exitCode, 0, "fake agy should exit 0");
+	assert.equal(
+		events.filter((e) => e.kind === "text").length,
+		0,
+		"undecodable row must not produce text",
+	);
+	assert.equal(warnings.length, 1, `expected exactly 1 warning, got ${warnings.length}`);
+
+	fs.rmSync(tmp, { recursive: true, force: true });
+});


### PR DESCRIPTION
   Fixes #1 

   ## Summary

   - Streams agent text from rows that agy commits as placeholders first and fills
     in place later (observed on agy 1.1.18).
   - Emits one visible warning per turn when completed text rows decode to zero
     characters, so future layout changes stop failing silently.

   ## What was wrong

   Recent agy versions commit an agent-text row as a metadata-only frame first
   (status 8, field 20 empty), then grow that same row in place to its final
   content. Verified present on agy 1.1.18 and absent on 1.1.7, both against
   official binaries; the introducing version is unknown.

   ## Changes

   | File                            | Change                                                                 |
   |---------------------------------|------------------------------------------------------------------------|
   | `src/runner.ts`                 | Track pending text rows from first sight; re-read until settled. Add turn-end zero-decode warning. |
   | `src/provider.ts`               | Surface the warning through the thinking stream.                       |
   | `scripts/run-agy.ts`            | Print the warning during standalone runs.                              |
   | `tests/runner-streaming.test.ts`| Add regressions: two-phase placeholder-to-filled streaming; undecodable-row warning. |
   | `docs/ARCHITECTURE.md`          | Document two-phase writes, polling behavior, thinking-layout drift.    |
   | `README.md`                     | State tested agy versions accurately.                                  |

   ## Compatibility

   Verified against real agy binaries at both ends of the range: 1.1.7 streams
   exactly as before (one live turn, byte-identical event output), and 1.1.18
   streams its two-phase rows correctly. Versions in between are untested but
   covered by design: decoding is version-agnostic, unknown payloads fail soft,
   and a turn whose completed text rows never decode emits one visible warning.
   The resume watermark keeps its existing max-seen semantics, so recovery stays
   bounded within a turn.

   ## Test plan

   - [x] `npm test`: 115/115 across 13 files, including the two new regressions
   - [x] `npx tsx scripts/test-provider.ts`: all checks pass, text_delta events flow end to end
   - [x] `npm run run-agy -- "Say hello"` streams incrementally on agy 1.1.18 (32 chars streamed; 0 before the fix)